### PR TITLE
media-control: use wireplumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,27 +20,28 @@ This is a Bash script that uses Dunst to show an indicator on the screen when th
 
 ## Installation
 
-1. Verify that all of the dependancies are installed
-2. Copy `volume_brightness.sh` to a folder on your computer
-3. Edit `~/.config/dunst/dunstrc`
-4. Under the `[global]` section, add `Font Awesome 5 Free Regular`
-5. Change `origin` to `bottom-center` or your desired location
-6. Edit `~/.config/i3/config`
-7. Add the following lines:
-	```
-	bindsym XF86AudioRaiseVolume exec --no-startup-id /path/to/volume_brightness.sh volume_up
-	bindsym XF86AudioLowerVolume exec --no-startup-id /path/to/volume_brightness.sh volume_down
-	bindsym XF86AudioMute exec --no-startup-id /path/to/volume_brightness.sh volume_mute
-    bindsym XF86MonBrightnessUp exec --no-startup-id /path/to/volume_brightness.sh brightness_up
-    bindsym XF86MonBrightnessDown exec --no-startup-id /path/to/volume_brightness.sh brightness_down
-    bindsym XF86AudioPlayPause exec --no-startup-id /path/to/volume_brightness.sh play_pause
-    bindsym XF86AudioPause exec --no-startup-id /path/to/volume_brightness.sh play_pause
-    bindsym XF86AudioPlay exec --no-startup-id /path/to/volume_brightness.sh play_pause
-    bindsym XF86AudioNext exec --no-startup-id /path/to/volume_brightness.sh next_track
-    bindsym XF86AudioPrev exec --no-startup-id /path/to/volume_brightness.sh prev_track
-	```
-8. Replace `/path/to/volume_brightness.sh` with the correct path to the script
-9. Edit `volume_brightness.sh` and set your desired values for the configuration options at the top
+1. Verify that all of the dependencies are installed
+2. Edit `media-control` and set your desired values for the configuration options at the top
+3. Copy `media-control` to a directory on your PATH
+4. Edit `~/.config/dunst/dunstrc`
+5. Under the `[global]` section, add `Font Awesome 5 Free Regular`
+6. Change `origin` to `bottom-center` or your desired location
+
+For i3 keybindings:
+1. Edit `~/.config/i3/config`
+2. Add the following lines:
+    ```
+    bindsym XF86AudioRaiseVolume exec --no-startup-id media-control volume_up
+    bindsym XF86AudioLowerVolume exec --no-startup-id media-control volume_down
+    bindsym XF86AudioMute exec --no-startup-id media-control volume_mute
+    bindsym XF86MonBrightnessUp exec --no-startup-id media-control brightness_up
+    bindsym XF86MonBrightnessDown exec --no-startup-id media-control brightness_down
+    bindsym XF86AudioPlayPause exec --no-startup-id media-control play_pause
+    bindsym XF86AudioPause exec --no-startup-id media-control play_pause
+    bindsym XF86AudioPlay exec --no-startup-id media-control play_pause
+    bindsym XF86AudioNext exec --no-startup-id media-control next_track
+    bindsym XF86AudioPrev exec --no-startup-id media-control prev_track
+    ```
 
 ## Configuration Reference
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Credits
+This is a fork of https://gitlab.com/Nmoleo/i3-volume-brightness-indicator
+
+The microphone control is based on https://gitlab.com/rituparnaw16/i3-volume-brightness-indicator/-/blob/main/volume_brightness.sh?ref_type=heads
+
 # Windows-Style Media & Brightness Notifications using Dunst
 
 ![](images/1.png)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a Bash script that uses Dunst to show an indicator on the screen when th
 
 ## Dependancies
 
-* PulseAudio
+* WirePlumber
 * [light](https://archlinux.org/packages/extra/x86_64/light/)
 * Font Awesome (`dnf install fontawesome-fonts fontawesome5-fonts` / `pacman -S ttf-font-awesome`)
 * dunst (`dnf install dunst` / `pacman -S dunst`)

--- a/media-control
+++ b/media-control
@@ -137,7 +137,6 @@ function show_mic_notif {
 # Displays a brightness notification using dunstify
 function show_brightness_notif {
     brightness=$(get_brightness)
-    echo $brightness
     get_brightness_icon
     notify-send -t $notification_timeout -h string:x-dunst-stack-tag:brightness_notif -h int:value:$brightness "$brightness_icon $brightness%"
 }

--- a/media-control
+++ b/media-control
@@ -126,16 +126,10 @@ function show_music_notif {
 
 # Displays mic notification
 function show_mic_notif {
-    mute=$(get_mic_mute)
     volume=$(get_mic_volume)
+    get_mic_icon  
 
-    get_mic_icon
-    if [ "$mute" == "no" ]; then
-        dunstify -t 1000 -r 2593 -u normal "$mic_icon $volume" -h int:value:$volume -h string:hlcolor:$bar_color
-    else
-        dunstify -t 1000 -r 2593 -u normal "$mic_icon $volume"
-    fi
-    # -h int:value:$brightness -h string:hlcolor:$bar_color
+    notify-send -t $notification_timeout -h string:x-dunst-stack-tag:mic_volume_notif -h int:value:$volume "$mic_icon $volume%"
 }
 
 # Displays a brightness notification using dunstify

--- a/media-control
+++ b/media-control
@@ -174,8 +174,6 @@ case $1 in
     # Brightness =========================================================
     brightness_up)
     # Increases brightness and displays the notification
-    
-
     brightnessctl s +$brightness_step%
     show_brightness_notif
     ;;
@@ -190,25 +188,19 @@ case $1 in
     next)
     # Skips to the next song and displays the notification
     playerctl next
-    # Some process on my device already provides notifications
-    # so I dont need these, even though they're perfect.
-    # sleep 0.2 && show_music_notif
+    sleep 0.5 && show_music_notif
     ;;
 
     prev)
     # Skips to the previous song and displays the notification
     playerctl previous
-    # Some process on my device already provides notifications
-    # so I dont need these, even though they're perfect.
-    # sleep 0.2 && show_music_notif
+    sleep 0.5 && show_music_notif
     ;;
 
     play_pause)
-    playerctl play-pause
-    # Some process on my device already provides notifications
-    # so I dont need these, even though they're perfect.
-    # show_music_notif
     # Pauses/resumes playback and displays the notification
+    playerctl play-pause
+    show_music_notif
     ;;
 
     # Microphone =========================================================
@@ -220,7 +212,7 @@ case $1 in
     if [ $(( "$mic_volume" + "$mic_volume_step" )) -gt $mic_max_volume ]; then
         pactl set-source-volume @DEFAULT_SOURCE@ $mic_max_volume%
     else
-        pactl set-source-volume @DEFAULT_SOURCE@ +$mic_volume_step
+        pactl set-source-volume @DEFAULT_SOURCE@ +$mic_volume_step%
     fi
     show_mic_notif
     ;;

--- a/media-control
+++ b/media-control
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# github https://github.com/Shringe/dunst-media-control
+
 # See README.md for usage instructions
 volume_step=5
 mic_volume_step=5
@@ -41,19 +43,19 @@ function get_volume_icon {
     volume=$(get_volume)
     mute=$(get_mute)
     if [ "$volume" -eq 0 ] || [ "$mute" == "yes" ] ; then
-        volume_icon=""
+        volume_icon="🔇"
     elif [ "$volume" -lt 50 ]; then
-        volume_icon=""
+        volume_icon=" "
     else
-        volume_icon=""
-    fi
+        volume_icon=" "
+    fi 
 }
 
 # Returns mute or unmute mic icon depending on mute status
 function get_mic_icon {
     mute=$(get_mic_mute)
     if [ "$mute" == "yes" ] ; then
-        mic_icon="/"
+        mic_icon="🎙️/"
     else
         mic_icon="🎙️"
     fi
@@ -181,13 +183,13 @@ case $1 in
     ;;
 
     # Media keys =========================================================
-    next_track)
+    next)
     # Skips to the next song and displays the notification
     playerctl next
     sleep 0.5 && show_music_notif
     ;;
 
-    prev_track)
+    prev)
     # Skips to the previous song and displays the notification
     playerctl previous
     sleep 0.5 && show_music_notif
@@ -220,7 +222,7 @@ case $1 in
     show_mic_notif
     ;; 
 
-    mic_toggle)
+    mic_mute)
     pactl set-source-mute @DEFAULT_SOURCE@ toggle
     show_mic_notif
     ;;

--- a/media-control
+++ b/media-control
@@ -9,9 +9,9 @@ brightness_step=5
 max_volume=100
 mic_max_volume=100
 notification_timeout=1000 # in milliseconds
-download_album_art=false
+download_album_art=true
 show_album_art=true
-show_music_in_volume_indicator=false
+show_music_in_volume_indicator=true
 
 # Uses regex to get volume from pactl
 function get_volume {

--- a/media-control
+++ b/media-control
@@ -9,9 +9,9 @@ brightness_step=5
 max_volume=100
 mic_max_volume=100
 notification_timeout=1000 # in milliseconds
-download_album_art=true
+download_album_art=false
 show_album_art=true
-show_music_in_volume_indicator=true
+show_music_in_volume_indicator=false
 
 # Uses regex to get volume from pactl
 function get_volume {
@@ -35,7 +35,12 @@ function get_mic_mute {
 
 # Uses regex to get brightness from xbacklight
 function get_brightness {
-    sudo light | grep -Po '[0-9]{1,3}' | head -n 1
+    declare -i absb
+    declare -i relb
+    absb=$(brightnessctl g)
+    maxb=$(brightnessctl m)
+    absb=$(( absb * 100 ))
+    echo $(( absb / maxb ))
 }
 
 # Returns a mute icon, a volume-low icon, or a volume-high icon, depending on the volume
@@ -106,7 +111,6 @@ function show_volume_notif {
         if [[ $show_album_art == "true" ]]; then
             get_album_art
         fi
-
         notify-send -t $notification_timeout -h string:x-dunst-stack-tag:volume_notif -h int:value:$volume -i "$album_art" "$volume_icon $volume%" "$current_song"
     else
         notify-send -t $notification_timeout -h string:x-dunst-stack-tag:volume_notif -h int:value:$volume "$volume_icon $volume%"
@@ -122,7 +126,6 @@ function show_music_notif {
     if [[ $show_album_art == "true" ]]; then
         get_album_art
     fi
-
     notify-send -t $notification_timeout -h string:x-dunst-stack-tag:music_notif -i "$album_art" "$song_title" "$song_artist - $song_album"
 }
 
@@ -137,7 +140,6 @@ function show_mic_notif {
 # Displays a brightness notification using dunstify
 function show_brightness_notif {
     brightness=$(get_brightness)
-    echo $brightness
     get_brightness_icon
     notify-send -t $notification_timeout -h string:x-dunst-stack-tag:brightness_notif -h int:value:$brightness "$brightness_icon $brightness%"
 }
@@ -172,13 +174,15 @@ case $1 in
     # Brightness =========================================================
     brightness_up)
     # Increases brightness and displays the notification
-    sudo light -A $brightness_step 
+    
+
+    brightnessctl s +$brightness_step%
     show_brightness_notif
     ;;
 
     brightness_down)
     # Decreases brightness and displays the notification
-    sudo light -U $brightness_step
+    brightnessctl s $brightness_step%-
     show_brightness_notif
     ;;
 
@@ -186,18 +190,24 @@ case $1 in
     next)
     # Skips to the next song and displays the notification
     playerctl next
-    sleep 0.5 && show_music_notif
+    # Some process on my device already provides notifications
+    # so I dont need these, even though they're perfect.
+    # sleep 0.2 && show_music_notif
     ;;
 
     prev)
     # Skips to the previous song and displays the notification
     playerctl previous
-    sleep 0.5 && show_music_notif
+    # Some process on my device already provides notifications
+    # so I dont need these, even though they're perfect.
+    # sleep 0.2 && show_music_notif
     ;;
 
     play_pause)
     playerctl play-pause
-    show_music_notif
+    # Some process on my device already provides notifications
+    # so I dont need these, even though they're perfect.
+    # show_music_notif
     # Pauses/resumes playback and displays the notification
     ;;
 
@@ -210,7 +220,7 @@ case $1 in
     if [ $(( "$mic_volume" + "$mic_volume_step" )) -gt $mic_max_volume ]; then
         pactl set-source-volume @DEFAULT_SOURCE@ $mic_max_volume%
     else
-        pactl set-source-volume @DEFAULT_SOURCE@ +$mic_volume_step%
+        pactl set-source-volume @DEFAULT_SOURCE@ +$mic_volume_step
     fi
     show_mic_notif
     ;;
@@ -218,7 +228,6 @@ case $1 in
     mic_down)
     # Lowers volume and displays the notification
     pactl set-source-volume @DEFAULT_SOURCE@ -$mic_volume_step%
-
     show_mic_notif
     ;; 
 

--- a/media-control
+++ b/media-control
@@ -2,8 +2,10 @@
 
 # See README.md for usage instructions
 volume_step=5
+mic_volume_step=5
 brightness_step=5
 max_volume=100
+mic_max_volume=100
 notification_timeout=1000 # in milliseconds
 download_album_art=true
 show_album_art=true
@@ -17,6 +19,16 @@ function get_volume {
 # Uses regex to get mute status from pactl
 function get_mute {
     pactl get-sink-mute @DEFAULT_SINK@ | grep -Po '(?<=Mute: )(yes|no)'
+}
+
+# Uses regex to get mic volume from pactl
+function get_mic_volume {
+    pactl get-source-volume @DEFAULT_SOURCE@ | grep -Po '[0-9]{1,3}(?=%)' | head -1
+}
+
+# Gets mic mute status
+function get_mic_mute {
+    pactl get-source-mute @DEFAULT_SOURCE@ | grep -Po '(?<=Mute: )(yes|no)'
 }
 
 # Uses regex to get brightness from xbacklight
@@ -34,6 +46,16 @@ function get_volume_icon {
         volume_icon=""
     else
         volume_icon=""
+    fi
+}
+
+# Returns mute or unmute mic icon depending on mute status
+function get_mic_icon {
+    mute=$(get_mic_mute)
+    if [ "$mute" == "yes" ] ; then
+        mic_icon="/"
+    else
+        mic_icon="🎙️"
     fi
 }
 
@@ -102,6 +124,20 @@ function show_music_notif {
     notify-send -t $notification_timeout -h string:x-dunst-stack-tag:music_notif -i "$album_art" "$song_title" "$song_artist - $song_album"
 }
 
+# Displays mic notification
+function show_mic_notif {
+    mute=$(get_mic_mute)
+    volume=$(get_mic_volume)
+
+    get_mic_icon
+    if [ "$mute" == "no" ]; then
+        dunstify -t 1000 -r 2593 -u normal "$mic_icon $volume" -h int:value:$volume -h string:hlcolor:$bar_color
+    else
+        dunstify -t 1000 -r 2593 -u normal "$mic_icon $volume"
+    fi
+    # -h int:value:$brightness -h string:hlcolor:$bar_color
+}
+
 # Displays a brightness notification using dunstify
 function show_brightness_notif {
     brightness=$(get_brightness)
@@ -112,6 +148,7 @@ function show_brightness_notif {
 
 # Main function - Takes user input, "volume_up", "volume_down", "brightness_up", or "brightness_down"
 case $1 in
+    # Volume =============================================================
     volume_up)
     # Unmutes and increases volume, then displays the notification
     pactl set-sink-mute @DEFAULT_SINK@ 0
@@ -125,7 +162,7 @@ case $1 in
     ;;
 
     volume_down)
-    # Raises volume and displays the notification
+    # Lowers volume and displays the notification
     pactl set-sink-volume @DEFAULT_SINK@ -$volume_step%
     show_volume_notif
     ;;
@@ -136,6 +173,7 @@ case $1 in
     show_volume_notif
     ;;
 
+    # Brightness =========================================================
     brightness_up)
     # Increases brightness and displays the notification
     sudo light -A $brightness_step 
@@ -148,6 +186,7 @@ case $1 in
     show_brightness_notif
     ;;
 
+    # Media keys =========================================================
     next_track)
     # Skips to the next song and displays the notification
     playerctl next
@@ -164,5 +203,31 @@ case $1 in
     playerctl play-pause
     show_music_notif
     # Pauses/resumes playback and displays the notification
+    ;;
+
+    # Microphone =========================================================
+    mic_up)
+    # Unmutes and increases volume, then displays the notification
+    pactl set-source-mute @DEFAULT_SOURCE@ 0
+    
+    mic_volume=$(get_mic_volume)
+    if [ $(( "$mic_volume" + "$mic_volume_step" )) -gt $mic_max_volume ]; then
+        pactl set-source-volume @DEFAULT_SOURCE@ $mic_max_volume%
+    else
+        pactl set-source-volume @DEFAULT_SOURCE@ +$mic_volume_step%
+    fi
+    show_mic_notif
+    ;;
+
+    mic_down)
+    # Lowers volume and displays the notification
+    pactl set-source-volume @DEFAULT_SOURCE@ -$mic_volume_step%
+
+    show_mic_notif
+    ;; 
+
+    mic_toggle)
+    pactl set-source-mute @DEFAULT_SOURCE@ toggle
+    show_mic_notif
     ;;
 esac

--- a/media-control
+++ b/media-control
@@ -13,24 +13,20 @@ download_album_art=true
 show_album_art=true
 show_music_in_volume_indicator=true
 
-# Uses regex to get volume from pactl
+# Uses regex to get volume from wpctl
 function get_volume {
-    pactl get-sink-volume @DEFAULT_SINK@ | grep -Po '[0-9]{1,3}(?=%)' | head -1
+    local volume
+    volume=$(wpctl get-volume "$1" | cut -d' ' -f2)
+    echo $(( volume * 100 ))
 }
 
-# Uses regex to get mute status from pactl
+# Uses regex to get mute status from wpctl
 function get_mute {
-    pactl get-sink-mute @DEFAULT_SINK@ | grep -Po '(?<=Mute: )(yes|no)'
-}
-
-# Uses regex to get mic volume from pactl
-function get_mic_volume {
-    pactl get-source-volume @DEFAULT_SOURCE@ | grep -Po '[0-9]{1,3}(?=%)' | head -1
-}
-
-# Gets mic mute status
-function get_mic_mute {
-    pactl get-source-mute @DEFAULT_SOURCE@ | grep -Po '(?<=Mute: )(yes|no)'
+    if wpctl get-volume "$1" | grep -q 'MUTED'; then
+        echo "yes"
+    else
+        echo "no"
+    fi
 }
 
 # Uses regex to get brightness from xbacklight
@@ -45,8 +41,8 @@ function get_brightness {
 
 # Returns a mute icon, a volume-low icon, or a volume-high icon, depending on the volume
 function get_volume_icon {
-    volume=$(get_volume)
-    mute=$(get_mute)
+    volume=$(get_volume @DEFAULT_SINK@)
+    mute=$(get_mute @DEFAULT_SINK@)
     if [ "$volume" -eq 0 ] || [ "$mute" == "yes" ] ; then
         volume_icon="🔇"
     elif [ "$volume" -lt 50 ]; then
@@ -58,7 +54,7 @@ function get_volume_icon {
 
 # Returns mute or unmute mic icon depending on mute status
 function get_mic_icon {
-    mute=$(get_mic_mute)
+    mute=$(get_mute @DEFAULT_SOURCE@)
     if [ "$mute" == "yes" ] ; then
         mic_icon="🎙️/"
     else
@@ -102,7 +98,7 @@ function get_album_art {
 
 # Displays a volume notification
 function show_volume_notif {
-    volume=$(get_mute)
+    volume=$(get_mute @DEFAULT_SINK@)
     get_volume_icon
 
     if [[ $show_music_in_volume_indicator == "true" ]]; then
@@ -131,7 +127,7 @@ function show_music_notif {
 
 # Displays mic notification
 function show_mic_notif {
-    volume=$(get_mic_volume)
+    volume=$(get_volume @DEFAULT_SOURCE@)
     get_mic_icon  
 
     notify-send -t $notification_timeout -h string:x-dunst-stack-tag:mic_volume_notif -h int:value:$volume "$mic_icon $volume%"
@@ -149,25 +145,25 @@ case $1 in
     # Volume =============================================================
     volume_up)
     # Unmutes and increases volume, then displays the notification
-    pactl set-sink-mute @DEFAULT_SINK@ 0
-    volume=$(get_volume)
+    wpctl set-mute @DEFAULT_SINK@ 0
+    volume=$(get_volume @DEFAULT_SINK@)
     if [ $(( "$volume" + "$volume_step" )) -gt $max_volume ]; then
-        pactl set-sink-volume @DEFAULT_SINK@ $max_volume%
+        wpctl set-volume @DEFAULT_SINK@ $max_volume%
     else
-        pactl set-sink-volume @DEFAULT_SINK@ +$volume_step%
+        wpctl set-volume @DEFAULT_SINK@ $volume_step%+
     fi
     show_volume_notif
     ;;
 
     volume_down)
     # Lowers volume and displays the notification
-    pactl set-sink-volume @DEFAULT_SINK@ -$volume_step%
+    wpctl set-volume @DEFAULT_SINK@ $volume_step%-
     show_volume_notif
     ;;
 
     volume_mute)
     # Toggles mute and displays the notification
-    pactl set-sink-mute @DEFAULT_SINK@ toggle
+    wpctl set-mute @DEFAULT_SINK@ toggle
     show_volume_notif
     ;;
 
@@ -206,25 +202,25 @@ case $1 in
     # Microphone =========================================================
     mic_up)
     # Unmutes and increases volume, then displays the notification
-    pactl set-source-mute @DEFAULT_SOURCE@ 0
+    wpctl set-mute @DEFAULT_SOURCE@ 0
     
-    mic_volume=$(get_mic_volume)
+    mic_volume=$(get_volume @DEFAULT_SOURCE@)
     if [ $(( "$mic_volume" + "$mic_volume_step" )) -gt $mic_max_volume ]; then
-        pactl set-source-volume @DEFAULT_SOURCE@ $mic_max_volume%
+        wpctl set-volume @DEFAULT_SOURCE@ $mic_max_volume%
     else
-        pactl set-source-volume @DEFAULT_SOURCE@ +$mic_volume_step%
+        wpctl set-volume @DEFAULT_SOURCE@ $mic_volume_step%+
     fi
     show_mic_notif
     ;;
 
     mic_down)
     # Lowers volume and displays the notification
-    pactl set-source-volume @DEFAULT_SOURCE@ -$mic_volume_step%
+    wpctl set-volume @DEFAULT_SOURCE@ $mic_volume_step%-
     show_mic_notif
     ;; 
 
     mic_mute)
-    pactl set-source-mute @DEFAULT_SOURCE@ toggle
+    wpctl set-source-mute @DEFAULT_SOURCE@ toggle
     show_mic_notif
     ;;
 esac

--- a/volume_brightness.sh
+++ b/volume_brightness.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # See README.md for usage instructions
-volume_step=1
+volume_step=5
 brightness_step=5
 max_volume=100
-notification_timeout=1000
+notification_timeout=1000 # in milliseconds
 download_album_art=true
 show_album_art=true
 show_music_in_volume_indicator=true


### PR DESCRIPTION
PulseAudio is being replaced by WirePlumber, so port from `pactl` to `wpctl`. One benefit is that `wpctl` doesn't have distinct commands for sources and sinks, so refactor queries to share logic.