### PR TITLE
Make `media-control` pass shellcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This is a Bash script that uses Dunst to show an indicator on the screen when th
 
 ## Dependancies
 
+* brightnessctl
+* playerctl
 * PulseAudio
 * [light](https://archlinux.org/packages/extra/x86_64/light/)
 * Font Awesome (`dnf install fontawesome-fonts fontawesome5-fonts` / `pacman -S ttf-font-awesome`)

--- a/media-control
+++ b/media-control
@@ -36,7 +36,6 @@ function get_mic_mute {
 # Uses regex to get brightness from xbacklight
 function get_brightness {
     declare -i absb
-    declare -i relb
     absb=$(brightnessctl g)
     maxb=$(brightnessctl m)
     absb=$(( absb * 100 ))
@@ -77,7 +76,7 @@ function get_album_art {
         album_art="${url/file:\/\//}"
     elif [[ $url == "http://"* ]] && [[ $download_album_art == "true" ]]; then
         # Identify filename from URL
-        filename="$(echo $url | sed "s/.*\///")"
+        filename="$(echo "$url" | sed "s/.*\///")"
 
         # Download file to /tmp if it doesn't exist
         if [ ! -f "/tmp/$filename" ]; then
@@ -87,7 +86,7 @@ function get_album_art {
         album_art="/tmp/$filename"
     elif [[ $url == "https://"* ]] && [[ $download_album_art == "true" ]]; then
         # Identify filename from URL
-        filename="$(echo $url | sed "s/.*\///")"
+        filename="$(echo "$url" | sed "s/.*\///")"
         
         # Download file to /tmp if it doesn't exist
         if [ ! -f "/tmp/$filename" ]; then
@@ -111,9 +110,9 @@ function show_volume_notif {
         if [[ $show_album_art == "true" ]]; then
             get_album_art
         fi
-        notify-send -t $notification_timeout -h string:x-dunst-stack-tag:volume_notif -h int:value:$volume -i "$album_art" "$volume_icon $volume%" "$current_song"
+        notify-send -t $notification_timeout -h string:x-dunst-stack-tag:volume_notif -h "int:value:$volume" -i "$album_art" "$volume_icon $volume%" "$current_song"
     else
-        notify-send -t $notification_timeout -h string:x-dunst-stack-tag:volume_notif -h int:value:$volume "$volume_icon $volume%"
+        notify-send -t $notification_timeout -h string:x-dunst-stack-tag:volume_notif -h "int:value:$volume" "$volume_icon $volume%"
     fi
 }
 
@@ -134,14 +133,14 @@ function show_mic_notif {
     volume=$(get_mic_volume)
     get_mic_icon  
 
-    notify-send -t $notification_timeout -h string:x-dunst-stack-tag:mic_volume_notif -h int:value:$volume "$mic_icon $volume%"
+    notify-send -t $notification_timeout -h string:x-dunst-stack-tag:mic_volume_notif -h "int:value:$volume" "$mic_icon $volume%"
 }
 
 # Displays a brightness notification using dunstify
 function show_brightness_notif {
     brightness=$(get_brightness)
     get_brightness_icon
-    notify-send -t $notification_timeout -h string:x-dunst-stack-tag:brightness_notif -h int:value:$brightness "$brightness_icon $brightness%"
+    notify-send -t $notification_timeout -h string:x-dunst-stack-tag:brightness_notif -h "int:value:$brightness" "$brightness_icon $brightness%"
 }
 
 # Main function - Takes user input, "volume_up", "volume_down", "brightness_up", or "brightness_down"


### PR DESCRIPTION
Greetings, and thanks for the excellent script!

While it works flawlessly for me, i did have to make a few tweaks. Nix users like myself would want to bundle this script with its dependencies into a shell application:

```nix
{ pkgs, ... }: {
  media-control = pkgs.writeShellApplication {
    name = "media-control";

    runtimeInputs = with pkgs; [
       brightnessctl
       light
       dunst
       playerctl
       pulseaudio /* can be skipped if pulseaudio or pipewire is already available */
     ];
     
     text = builtins.readFile ./media-control;
  };
}
```

However, nix runs all shell applications through [shellcheck](https://www.shellcheck.net/), which got a bit fussy about unquoted variables.

I also added `brightnessctl` and `playerctl` to the list of dependencies, as (on nix) they weren't included with the rest of the listed dependencies.

Thanks again!